### PR TITLE
[DVO-3104] Allow specifying static whitelists and blacklists at provision time.

### DIFF
--- a/deployment/aws-waf-security-automations-webacl.template
+++ b/deployment/aws-waf-security-automations-webacl.template
@@ -49,6 +49,14 @@ Parameters:
     Type: String
   LogLevel:
     Type: String
+  WAFBlacklistSetV4Addresses:
+    Type: CommaDelimitedList
+  WAFBlacklistSetV6Addresses:
+    Type: CommaDelimitedList
+  WAFWhitelistSetV4Addresses:
+    Type: CommaDelimitedList
+  WAFWhitelistSetV6Addresses:
+    Type: CommaDelimitedList
 
 Conditions:
   AWSManagedRulesActivated: !Equals
@@ -98,6 +106,22 @@ Conditions:
   BadBotProtectionActivated: !Equals
     - !Ref ActivateBadBotProtectionParam
     - 'yes'
+
+  WAFBlacklistSetV4AddressesEmpty: !Equals
+    - !Join [",", !Ref WAFBlacklistSetV4Addresses]
+    - ""
+
+  WAFBlacklistSetV6AddressesEmpty: !Equals
+    - !Join [",", !Ref WAFBlacklistSetV6Addresses]
+    - ""
+
+  WAFWhitelistSetV4AddressesEmpty: !Equals
+    - !Join [",", !Ref WAFWhitelistSetV4Addresses]
+    - ""
+
+  WAFWhitelistSetV6AddressesEmpty: !Equals
+    - !Join [",", !Ref WAFWhitelistSetV6Addresses]
+    - ""
 
 Mappings:
   SourceCode:
@@ -192,7 +216,7 @@ Resources:
       IPAddressVersion: 'IPV4'
       Name: !Sub '${ParentStackName}WhitelistSetIPV4'
       Description: 'Allow whitelist for IPV4 addresses'
-      Addresses: []
+      Addresses: !If [WAFWhitelistSetV4AddressesEmpty, [], !Ref WAFWhitelistSetV4Addresses]
 
   WAFBlacklistSetV4:
     Type: 'AWS::WAFv2::IPSet'
@@ -202,7 +226,7 @@ Resources:
       IPAddressVersion: 'IPV4'
       Name: !Sub '${ParentStackName}BlacklistSetIPV4'
       Description: 'Block blacklist for IPV4 addresses'
-      Addresses: []
+      Addresses: !If [WAFBlacklistSetV4AddressesEmpty, [], !Ref WAFBlacklistSetV4Addresses]
 
   WAFHttpFloodSetV4:
     Type: 'AWS::WAFv2::IPSet'
@@ -260,7 +284,7 @@ Resources:
       IPAddressVersion: IPV6
       Name: !Sub '${ParentStackName}WhitelistSetIPV6'
       Description: 'Allow whitelist for IPV6 addresses'
-      Addresses: []
+      Addresses: !If [WAFWhitelistSetV6AddressesEmpty, [], !Ref WAFWhitelistSetV6Addresses]
 
   WAFBlacklistSetV6:
     Type: 'AWS::WAFv2::IPSet'
@@ -270,7 +294,7 @@ Resources:
       IPAddressVersion: IPV6
       Name: !Sub '${ParentStackName}BlacklistSetIPV6'
       Description: 'Block blacklist for IPV6 addresses'
-      Addresses: []
+      Addresses: !If [WAFBlacklistSetV6AddressesEmpty, [], !Ref WAFBlacklistSetV6Addresses]
 
   WAFHttpFloodSetV6:
     Type: 'AWS::WAFv2::IPSet'

--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -48,6 +48,10 @@ Metadata:
           - RequestThreshold
           - WAFBlockPeriod
           - KeepDataInOriginalS3Location
+          - WAFBlacklistSetV4Addresses
+          - WAFBlacklistSetV6Addresses
+          - WAFWhitelistSetV4Addresses
+          - WAFWhitelistSetV6Addresses
 
     ParameterLabels:
       ActivateAWSManagedRulesParam:
@@ -83,8 +87,20 @@ Metadata:
       RequestThreshold:
         default: Request Threshold
 
+      WAFBlacklistSetV4Addresses:
+        default: IPv4 Address Blacklist
+
+      WAFBlacklistSetV6Addresses:
+        default: IPv6 Address Blacklist
+
       WAFBlockPeriod:
         default: WAF Block Period
+
+      WAFWhitelistSetV4Addresses:
+        default: IPv4 Address Whitelist
+
+      WAFWhitelistSetV6Addresses:
+        default: IPv6 Address Whitelist
 
       KeepDataInOriginalS3Location:
         default: Keep Data in Original s3 location
@@ -189,6 +205,20 @@ Parameters:
       you can use any value greater than zero). If you chose to deactivate this protection, ignore
       this parameter.
 
+  WAFBlacklistSetV4Addresses:
+    Type: CommaDelimitedList
+    Default: ""
+    Description:  >-
+      A list of IPv4 addresses to explicitly disallow from reaching resources protected by the web
+      ACL. Ignore this parameter to prevent any IPv4 addresses from being explicitly disallowed.
+
+  WAFBlacklistSetV6Addresses:
+    Type: CommaDelimitedList
+    Default: ""
+    Description:  >-
+      A list of IPv6 addresses to explicitly disallow from reaching resources protected by the web
+      ACL. Ignore this parameter to prevent any IPv6 addresses from being explicitly disallowed.
+
   WAFBlockPeriod:
     Type: Number
     Default: 240
@@ -197,6 +227,22 @@ Parameters:
       If you chose yes for the Activate Scanners & Probes Protection or HTTP Flood Lambda/Athena log
       parser parameters, enter the period (in minutes) to block applicable IP addresses. If you
       chose to deactivate log parsing, ignore this parameter.
+
+  WAFWhitelistSetV4Addresses:
+    Type: CommaDelimitedList
+    Default: ""
+    Description:  >-
+      A list of IPv4 addresses to explicitly allow to reach resources protected by the web ACL.
+      Addresses on this list will bypass all other protections, and always be allowed through.
+      Ignore this parameter to prevent any IPv4 addresses from being explicitly allowed.
+
+  WAFWhitelistSetV6Addresses:
+    Type: CommaDelimitedList
+    Default: ""
+    Description:  >-
+      A list of IPv6 addresses to explicitly allow to reach resources protected by the web ACL.
+      Addresses on this list will bypass all other protections, and always be allowed through.
+      Ignore this parameter to prevent any IPv4 addresses from being explicitly allowed.
 
   KeepDataInOriginalS3Location:
     Type: String
@@ -355,6 +401,10 @@ Resources:
         GlueAppAccessLogsTable: !If [ScannersProbesAthenaLogParser, !GetAtt FirehoseAthenaStack.Outputs.GlueAppAccessLogsTable, '']
         GlueWafAccessLogsTable: !If [HttpFloodAthenaLogParser, !GetAtt FirehoseAthenaStack.Outputs.GlueWafAccessLogsTable,'']
         LogLevel: !FindInMap ["Solution", "Data", "LogLevel"]
+        WAFBlacklistSetV4Addresses: !Join [",", !Ref WAFBlacklistSetV4Addresses]
+        WAFBlacklistSetV6Addresses: !Join [",", !Ref WAFBlacklistSetV6Addresses]
+        WAFWhitelistSetV4Addresses: !Join [",", !Ref WAFWhitelistSetV4Addresses]
+        WAFWhitelistSetV6Addresses: !Join [",", !Ref WAFWhitelistSetV6Addresses]
 
 
 


### PR DESCRIPTION
When the stack is deployed, the whitelist and blacklist are both initialized to empty. If they are modified manually, and the stack is updated, any manual changes are removed, resulting in empty lists.

This change allows CloudFormation to optionally manage the contents of these lists, so that they are not wiped out on update.