### PR TITLE
[DVO-3104] Parameterize the WAF's default action.

### DIFF
--- a/deployment/aws-waf-security-automations-webacl.template
+++ b/deployment/aws-waf-security-automations-webacl.template
@@ -35,6 +35,8 @@ Parameters:
     Type: String
   ActivateBadBotProtectionParam:
     Type: String
+  DefaultAction:
+    Type: String
   RequestThreshold:
     Type: Number
   RegionScope:
@@ -62,6 +64,14 @@ Conditions:
   AWSManagedRulesActivated: !Equals
     - !Ref ActivateAWSManagedRulesParam
     - 'yes'
+
+  DefaultActionIsAllow: !Equals
+    - !Ref DefaultAction
+    - "Allow"
+
+  DefaultActionIsBlock: !Equals
+    - !Ref DefaultAction
+    - "Block"
 
   SqlInjectionProtectionActivated: !Equals
     - !Ref ActivateSqlInjectionProtectionParam
@@ -394,7 +404,8 @@ Resources:
         CloudWatchMetricsEnabled: true
         MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'WAFWebACL']]
       DefaultAction:
-        Allow: {}
+        Allow: !If [DefaultActionIsAllow, {}, !Ref "AWS::NoValue"]
+        Block: !If [DefaultActionIsBlock, {}, !Ref "AWS::NoValue"]
       Rules:
         - !If
           - AWSManagedRulesActivated

--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -44,6 +44,7 @@ Metadata:
       - Label:
           default: Advanced Settings
         Parameters:
+          - DefaultAction
           - ErrorThreshold
           - RequestThreshold
           - WAFBlockPeriod
@@ -74,6 +75,9 @@ Metadata:
 
       ActivateBadBotProtectionParam:
         default: Activate Bad Bot Protection
+
+      DefaultAction:
+        default: Default Action of Web ACL
 
       EndpointType:
         default: Endpoint Type
@@ -166,6 +170,16 @@ Parameters:
       - 'yes'
       - 'no'
     Description: Choose yes to enable the component designed to block bad bots and content scrapers.
+
+  DefaultAction:
+    Type: String
+    Default: "Allow"
+    AllowedValues:
+      - "Allow"
+      - "Block"
+    Description: >-
+      Set to Allow to allow traffic that is not matched by any rule in the WAF web ACL. Set to
+      Block to block this traffic instead.
 
   EndpointType:
     Type: String
@@ -394,6 +408,7 @@ Resources:
         ActivateScannersProbesProtectionParam: !Ref ActivateScannersProbesProtectionParam
         ActivateReputationListsProtectionParam: !Ref ActivateReputationListsProtectionParam
         ActivateBadBotProtectionParam: !Ref ActivateBadBotProtectionParam
+        DefaultAction: !Ref DefaultAction
         RequestThreshold: !Ref RequestThreshold
         RegionScope: !If [AlbEndpoint, 'REGIONAL', 'CLOUDFRONT']
         ParentStackName: !Ref 'AWS::StackName'


### PR DESCRIPTION
This change parameterizes the default action of the WAF, so that the stack can be deployed in a test mode where protections are enabled, but traffic from the outside world is not enabled.